### PR TITLE
CI: fix release workflow permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,8 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Add `contents: write` permission so the workflow can create GitHub Releases.

Key changes:
- `.github/workflows/release.yml` — add `permissions: contents: write`