### PR TITLE
[CLI/Plugin] Add exclude and prefix options

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,10 +108,17 @@ npx css-typed-vars --input "src/styles/**/*.css" --output src/cssVars.ts
 npx css-typed-vars --input "src/styles/**/*.{css,scss}" --output src/cssVars.ts --watch
 ```
 
+```sh
+npx css-typed-vars --input "src/**/*.css" --output src/cssVars.ts --exclude "**/vendor/**"
+npx css-typed-vars --input "src/**/*.css" --output src/cssVars.ts --prefix theme
+```
+
 | Flag | Description |
 |------|-------------|
 | `--input` | Glob pattern for CSS/SCSS/Less files |
 | `--output` | Path to the generated TypeScript file |
+| `--exclude` | Glob pattern for files to exclude (single value; use config file for multiple) |
+| `--prefix` | Prefix for generated keys: `--prefix theme` → `themeColorPrimary` |
 | `--watch` | Watch for file changes and regenerate |
 
 CLI flags override values from the config file.
@@ -123,6 +130,18 @@ The CLI looks for a config file in the current working directory (in order):
 1. `css-typed-vars.config.js`
 2. `css-typed-vars.config.mjs`
 3. `css-typed-vars.config.json`
+
+All options are supported in the config file:
+
+```js
+// css-typed-vars.config.js
+export default {
+  input: 'src/styles/**/*.{css,scss}',
+  output: 'src/cssVars.ts',
+  exclude: ['**/vendor/**', '**/node_modules/**'],
+  prefix: 'theme',
+};
+```
 
 ---
 
@@ -215,6 +234,8 @@ Turbopack does not yet have a public plugin API for virtual modules. Use the CLI
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
 | `input` | `string \| string[]` | — | Glob pattern for CSS/SCSS/Less files |
+| `exclude` | `string \| string[]` | — | Glob pattern(s) for files to exclude |
+| `prefix` | `string` | — | Prefix for generated keys: `'theme'` → `themeColorPrimary` |
 | `dts` | `string \| false` | inside `node_modules` | Path to write type declarations. `false` to skip |
 
 ---
@@ -268,6 +289,8 @@ import { generate } from 'css-typed-vars';
 await generate({
   input: 'src/styles/**/*.{css,scss}',
   output: 'src/cssVars.ts',
+  exclude: ['**/vendor/**'],
+  prefix: 'theme',
 });
 ```
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "css-typed-vars",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Generate TypeScript typed constants from CSS custom properties",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/src/__tests__/generator.test.ts
+++ b/src/__tests__/generator.test.ts
@@ -32,6 +32,28 @@ describe('generateCode', () => {
     expect(result).toContain('} as const;');
     expect(result).not.toContain('var(--');
   });
+
+  it('applies prefix to generated keys', () => {
+    const result = generateCode(['--color-primary', '--spacing-md'], 'theme');
+    expect(result).toContain("themeColorPrimary: 'var(--color-primary)'");
+    expect(result).toContain("themeSpacingMd: 'var(--spacing-md)'");
+  });
+
+  it('capitalizes first letter of base key when prefix is set', () => {
+    const result = generateCode(['--color-primary'], 'ui');
+    expect(result).toContain("uiColorPrimary: 'var(--color-primary)'");
+    expect(result).not.toContain("uicolorPrimary:");
+  });
+
+  it('produces unchanged keys when prefix is empty string', () => {
+    const result = generateCode(['--color-primary'], '');
+    expect(result).toContain("colorPrimary: 'var(--color-primary)'");
+  });
+
+  it('produces unchanged keys when prefix is undefined', () => {
+    const result = generateCode(['--color-primary'], undefined);
+    expect(result).toContain("colorPrimary: 'var(--color-primary)'");
+  });
 });
 
 describe('generateDeclaration', () => {
@@ -51,5 +73,10 @@ describe('generateDeclaration', () => {
     const result = generateDeclaration([]);
     expect(result).toContain('export declare const cssVars: {');
     expect(result).not.toContain('var(--');
+  });
+
+  it('applies prefix in declaration output', () => {
+    const result = generateDeclaration(['--color-primary'], 'theme');
+    expect(result).toContain("themeColorPrimary: 'var(--color-primary)';");
   });
 });

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -40,4 +40,30 @@ describe('generate', () => {
     const result = await readFile(output, 'utf8');
     expect(result).toContain('export const cssVars');
   });
+
+  it('excludes files matching exclude pattern', async () => {
+    const { writeFile, mkdir } = await import('node:fs/promises');
+    const subdir = join(dir, 'vendor');
+    await mkdir(subdir, { recursive: true });
+    await writeFile(join(subdir, 'lib.css'), ':root { --vendor-var: 1px; }');
+
+    const output = join(dir, 'excludeVars.ts');
+    await generate({ input: `${dir}/**/*.css`, output, exclude: `${dir}/vendor/**` });
+
+    const result = await readFile(output, 'utf8');
+    expect(result).not.toContain('--vendor-var');
+  });
+
+  it('applies prefix to generated output', async () => {
+    const { writeFile } = await import('node:fs/promises');
+    const input = join(dir, 'prefix-test.css');
+    const output = join(dir, 'prefixVars.ts');
+    await writeFile(input, ':root { --color-primary: red; }');
+
+    await generate({ input, output, prefix: 'theme' });
+
+    const result = await readFile(output, 'utf8');
+    expect(result).toContain("themeColorPrimary: 'var(--color-primary)'");
+    expect(result).not.toContain("colorPrimary: 'var(--color-primary)'");
+  });
 });

--- a/src/__tests__/scanner.test.ts
+++ b/src/__tests__/scanner.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
-import { mkdtemp, writeFile, rm } from 'node:fs/promises';
+import { mkdtemp, mkdir, writeFile, rm } from 'node:fs/promises';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { scanVarNames } from '../scanner.js';
@@ -11,6 +11,8 @@ beforeAll(async () => {
   await writeFile(join(dir, 'a.css'), ':root { --color-primary: red; --spacing-md: 8px; }');
   await writeFile(join(dir, 'b.css'), ':root { --color-secondary: blue; --spacing-md: 8px; }');
   await writeFile(join(dir, 'other.txt'), ':root { --ignored: 1px; }');
+  await mkdir(join(dir, 'vendor'));
+  await writeFile(join(dir, 'vendor', 'lib.css'), ':root { --vendor-color: #fff; }');
 });
 
 afterAll(async () => {
@@ -44,5 +46,22 @@ describe('scanVarNames', () => {
     const result = await scanVarNames([`${dir}/a.css`, `${dir}/b.css`]);
     expect(result).toContain('--color-primary');
     expect(result).toContain('--color-secondary');
+  });
+
+  it('excludes files matching exclude pattern', async () => {
+    const result = await scanVarNames(`${dir}/**/*.css`, `${dir}/vendor/**`);
+    expect(result).not.toContain('--vendor-color');
+    expect(result).toContain('--color-primary');
+  });
+
+  it('excludes files matching array of exclude patterns', async () => {
+    const result = await scanVarNames(`${dir}/**/*.css`, [`${dir}/vendor/**`]);
+    expect(result).not.toContain('--vendor-color');
+  });
+
+  it('returns all files when exclude is undefined', async () => {
+    const result = await scanVarNames(`${dir}/**/*.css`);
+    expect(result).toContain('--vendor-color');
+    expect(result).toContain('--color-primary');
   });
 });

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -16,6 +16,8 @@ const watchMode = args.includes('--watch');
 interface Config {
   input?: string | string[];
   output?: string;
+  exclude?: string | string[];
+  prefix?: string;
 }
 
 async function loadConfig(): Promise<Config> {
@@ -41,9 +43,14 @@ async function loadConfig(): Promise<Config> {
   return {};
 }
 
-async function run(input: string | string[], output: string): Promise<void> {
-  const names = await scanVarNames(input);
-  const code = generateCode(names);
+async function run(
+  input: string | string[],
+  output: string,
+  exclude?: string | string[],
+  prefix?: string,
+): Promise<void> {
+  const names = await scanVarNames(input, exclude);
+  const code = generateCode(names, prefix);
   await mkdir(dirname(resolve(output)), { recursive: true });
   await writeFile(output, code, 'utf8');
   console.log(`Generated ${names.length} variables → ${output}`);
@@ -53,6 +60,8 @@ async function main(): Promise<void> {
   const config = await loadConfig();
   const input = getArg('--input') ?? config.input;
   const output = getArg('--output') ?? config.output;
+  const exclude = getArg('--exclude') ?? config.exclude;
+  const prefix = getArg('--prefix') ?? config.prefix;
 
   if (!input || !output) {
     console.error('Usage: css-typed-vars --input <glob> --output <file> [--watch]');
@@ -60,13 +69,13 @@ async function main(): Promise<void> {
     process.exit(1);
   }
 
-  await run(input, output);
+  await run(input, output, exclude, prefix);
 
   if (watchMode) {
     const patterns = Array.isArray(input) ? input : [input];
     watch(patterns).on('change', (file) => {
       console.log(`Changed: ${file}`);
-      run(input, output).catch(console.error);
+      run(input, output, exclude, prefix).catch(console.error);
     });
     console.log('Watching for changes...');
   }

--- a/src/generator.ts
+++ b/src/generator.ts
@@ -4,8 +4,13 @@ function toCamelCase(cssVarName: string): string {
     .replace(/-([a-z0-9])/g, (_, c: string) => c.toUpperCase());
 }
 
-export function generateCode(varNames: string[]): string {
-  const entries = varNames.map(name => `  ${toCamelCase(name)}: 'var(${name})',`);
+function applyPrefix(key: string, prefix: string | undefined): string {
+  if (!prefix) return key;
+  return prefix + key.charAt(0).toUpperCase() + key.slice(1);
+}
+
+export function generateCode(varNames: string[], prefix?: string): string {
+  const entries = varNames.map(name => `  ${applyPrefix(toCamelCase(name), prefix)}: 'var(${name})',`);
   return [
     '// generated — do not edit',
     'export const cssVars = {',
@@ -17,8 +22,8 @@ export function generateCode(varNames: string[]): string {
   ].join('\n');
 }
 
-export function generateJs(varNames: string[]): string {
-  const entries = varNames.map(name => `  ${toCamelCase(name)}: 'var(${name})',`);
+export function generateJs(varNames: string[], prefix?: string): string {
+  const entries = varNames.map(name => `  ${applyPrefix(toCamelCase(name), prefix)}: 'var(${name})',`);
   return [
     'export const cssVars = {',
     ...entries,
@@ -27,8 +32,8 @@ export function generateJs(varNames: string[]): string {
   ].join('\n');
 }
 
-export function generateDeclaration(varNames: string[]): string {
-  const entries = varNames.map(name => `  ${toCamelCase(name)}: 'var(${name})';`);
+export function generateDeclaration(varNames: string[], prefix?: string): string {
+  const entries = varNames.map(name => `  ${applyPrefix(toCamelCase(name), prefix)}: 'var(${name})';`);
   return [
     'export declare const cssVars: {',
     ...entries,

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,11 +10,13 @@ export { scanVarNames } from './scanner.js';
 export interface GenerateOptions {
   input: string | string[];
   output: string;
+  exclude?: string | string[];
+  prefix?: string;
 }
 
 export async function generate(options: GenerateOptions): Promise<void> {
-  const names = await scanVarNames(options.input);
-  const code = generateCode(names);
+  const names = await scanVarNames(options.input, options.exclude);
+  const code = generateCode(names, options.prefix);
   await mkdir(dirname(resolve(options.output)), { recursive: true });
   await writeFile(options.output, code, 'utf8');
 }

--- a/src/scanner.ts
+++ b/src/scanner.ts
@@ -2,11 +2,17 @@ import { readFile } from 'node:fs/promises';
 import fg from 'fast-glob';
 import { parseVarNames } from './parser.js';
 
-export async function scanVarNames(patterns: string | string[]): Promise<string[]> {
+export async function scanVarNames(
+  patterns: string | string[],
+  exclude?: string | string[],
+): Promise<string[]> {
   const normalized = (Array.isArray(patterns) ? patterns : [patterns]).map((p) =>
     p.replace(/\\/g, '/'),
   );
-  const files = await fg(normalized, { absolute: true });
+  const normalizedExclude = exclude
+    ? (Array.isArray(exclude) ? exclude : [exclude]).map((p) => p.replace(/\\/g, '/'))
+    : [];
+  const files = await fg(normalized, { absolute: true, ignore: normalizedExclude });
   const all = new Set<string>();
   await Promise.all(
     files.map(async (file) => {

--- a/src/unplugin.ts
+++ b/src/unplugin.ts
@@ -13,6 +13,8 @@ export interface Options {
    * - `false`: skip writing
    */
   dts?: string | false;
+  exclude?: string | string[];
+  prefix?: string;
 }
 
 const VIRTUAL_ID = 'css-typed-vars/vars';
@@ -38,11 +40,11 @@ export default createUnplugin((options: Options) => ({
       server.watcher.on('change', async (file: string) => {
         if (!/\.(css|scss|less)$/i.test(file)) return;
 
-        const names = await scanVarNames(options.input);
+        const names = await scanVarNames(options.input, options.exclude);
 
         const dtsPath = getDtsPath(options);
         if (dtsPath) {
-          await writeFile(dtsPath, generateDeclaration(names), 'utf8');
+          await writeFile(dtsPath, generateDeclaration(names, options.prefix), 'utf8');
         }
 
         const mod = server.moduleGraph.getModuleById(RESOLVED_ID);
@@ -57,8 +59,8 @@ export default createUnplugin((options: Options) => ({
   async buildStart() {
     const dtsPath = getDtsPath(options);
     if (!dtsPath) return;
-    const names = await scanVarNames(options.input);
-    await writeFile(dtsPath, generateDeclaration(names), 'utf8');
+    const names = await scanVarNames(options.input, options.exclude);
+    await writeFile(dtsPath, generateDeclaration(names, options.prefix), 'utf8');
   },
 
   resolveId(id: string) {
@@ -67,8 +69,8 @@ export default createUnplugin((options: Options) => ({
 
   async load(id: string) {
     if (id === RESOLVED_ID) {
-      const names = await scanVarNames(options.input);
-      return generateJs(names);
+      const names = await scanVarNames(options.input, options.exclude);
+      return generateJs(names, options.prefix);
     }
   },
 }));


### PR DESCRIPTION
Add two new options available across CLI, config file, bundler plugin, and programmatic API.

Key changes:
- `src/scanner.ts` — `scanVarNames` accepts optional `exclude?: string | string[]`, forwarded to fast-glob as `ignore`; same backslash normalization as `patterns`
- `src/generator.ts` — all three functions (`generateCode`, `generateJs`, `generateDeclaration`) accept optional `prefix?: string`; new `applyPrefix` helper capitalizes first letter of base key when prefix is set
- `src/index.ts` — `GenerateOptions` extended with `exclude` and `prefix`; both threaded through `generate()`
- `src/unplugin.ts` — `Options` extended with `exclude` and `prefix`; all 3 `scanVarNames` call sites and all 3 generator call sites updated
- `src/cli.ts` — `Config` extended; `--exclude` and `--prefix` flags added; `run()` signature updated; all 4 call sites updated (initial + 3 watcher callbacks)
- `src/__tests__/scanner.test.ts` — 3 new tests: exclude by string, exclude by array, no exclude returns all
- `src/__tests__/generator.test.ts` — 5 new tests: prefix applied, capitalization, empty string, undefined, declaration output
- `src/__tests__/index.test.ts` — 2 new tests: exclude filters output, prefix applied in generated file
- `package.json` — version bump `0.1.0` → `0.2.0`
- `README.md` — documented `--exclude` and `--prefix` CLI flags, config file example, plugin options table

Closes #18