### PR TITLE
[Generator] Add naming convention option and JS output

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,15 +110,17 @@ npx css-typed-vars --input "src/styles/**/*.{css,scss}" --output src/cssVars.ts 
 
 ```sh
 npx css-typed-vars --input "src/**/*.css" --output src/cssVars.ts --exclude "**/vendor/**"
-npx css-typed-vars --input "src/**/*.css" --output src/cssVars.ts --prefix theme
+npx css-typed-vars --input "src/**/*.css" --output src/cssVars.ts --prefix theme --naming snake
+npx css-typed-vars --input "src/**/*.css" --output src/cssVars.js  # generates .js + .d.ts
 ```
 
 | Flag | Description |
 |------|-------------|
 | `--input` | Glob pattern for CSS/SCSS/Less files |
-| `--output` | Path to the generated TypeScript file |
+| `--output` | Output file. `.ts` → TypeScript, `.js` → JavaScript + `.d.ts` alongside |
 | `--exclude` | Glob pattern for files to exclude (single value; use config file for multiple) |
 | `--prefix` | Prefix for generated keys: `--prefix theme` → `themeColorPrimary` |
+| `--naming` | Key naming: `camelCase` (default), `snake`, `kebab` |
 | `--watch` | Watch for file changes and regenerate |
 
 CLI flags override values from the config file.
@@ -140,6 +142,7 @@ export default {
   output: 'src/cssVars.ts',
   exclude: ['**/vendor/**', '**/node_modules/**'],
   prefix: 'theme',
+  naming: 'snake', // 'camelCase' | 'snake' | 'kebab'
 };
 ```
 
@@ -236,6 +239,7 @@ Turbopack does not yet have a public plugin API for virtual modules. Use the CLI
 | `input` | `string \| string[]` | — | Glob pattern for CSS/SCSS/Less files |
 | `exclude` | `string \| string[]` | — | Glob pattern(s) for files to exclude |
 | `prefix` | `string` | — | Prefix for generated keys: `'theme'` → `themeColorPrimary` |
+| `naming` | `'camelCase' \| 'snake' \| 'kebab'` | `'camelCase'` | Key naming convention |
 | `dts` | `string \| false` | inside `node_modules` | Path to write type declarations. `false` to skip |
 
 ---
@@ -288,9 +292,10 @@ import { generate } from 'css-typed-vars';
 
 await generate({
   input: 'src/styles/**/*.{css,scss}',
-  output: 'src/cssVars.ts',
+  output: 'src/cssVars.ts',  // or 'src/cssVars.js' → generates .js + .d.ts
   exclude: ['**/vendor/**'],
   prefix: 'theme',
+  naming: 'snake',           // 'camelCase' | 'snake' | 'kebab'
 });
 ```
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "css-typed-vars",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Generate TypeScript typed constants from CSS custom properties",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/src/__tests__/generator.test.ts
+++ b/src/__tests__/generator.test.ts
@@ -54,6 +54,28 @@ describe('generateCode', () => {
     const result = generateCode(['--color-primary'], undefined);
     expect(result).toContain("colorPrimary: 'var(--color-primary)'");
   });
+
+  it('snake naming converts hyphens to underscores', () => {
+    const result = generateCode(['--color-primary', '--spacing-md'], undefined, 'snake');
+    expect(result).toContain("color_primary: 'var(--color-primary)'");
+    expect(result).toContain("spacing_md: 'var(--spacing-md)'");
+  });
+
+  it('kebab naming strips -- and keeps hyphens as quoted key', () => {
+    const result = generateCode(['--color-primary', '--spacing-md'], undefined, 'kebab');
+    expect(result).toContain("'color-primary': 'var(--color-primary)'");
+    expect(result).toContain("'spacing-md': 'var(--spacing-md)'");
+  });
+
+  it('snake naming with prefix uses underscore separator', () => {
+    const result = generateCode(['--color-primary'], 'theme', 'snake');
+    expect(result).toContain("theme_color_primary: 'var(--color-primary)'");
+  });
+
+  it('kebab naming with prefix uses hyphen separator', () => {
+    const result = generateCode(['--color-primary'], 'theme', 'kebab');
+    expect(result).toContain("'theme-color-primary': 'var(--color-primary)'");
+  });
 });
 
 describe('generateDeclaration', () => {

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -54,6 +54,34 @@ describe('generate', () => {
     expect(result).not.toContain('--vendor-var');
   });
 
+  it('generates JS file and .d.ts when output ends in .js', async () => {
+    const { writeFile } = await import('node:fs/promises');
+    const input = join(dir, 'js-test.css');
+    const output = join(dir, 'cssVars.js');
+    await writeFile(input, ':root { --color-primary: red; }');
+
+    await generate({ input, output });
+
+    const js = await readFile(join(dir, 'cssVars.js'), 'utf8');
+    const dts = await readFile(join(dir, 'cssVars.d.ts'), 'utf8');
+    expect(js).toContain("colorPrimary: 'var(--color-primary)'");
+    expect(js).not.toContain('as const');
+    expect(dts).toContain('export declare const cssVars');
+    expect(dts).toContain("colorPrimary: 'var(--color-primary)';");
+  });
+
+  it('applies snake naming to generated output', async () => {
+    const { writeFile } = await import('node:fs/promises');
+    const input = join(dir, 'naming-test.css');
+    const output = join(dir, 'snakeVars.ts');
+    await writeFile(input, ':root { --color-primary: red; }');
+
+    await generate({ input, output, naming: 'snake' });
+
+    const result = await readFile(output, 'utf8');
+    expect(result).toContain("color_primary: 'var(--color-primary)'");
+  });
+
   it('applies prefix to generated output', async () => {
     const { writeFile } = await import('node:fs/promises');
     const input = join(dir, 'prefix-test.css');

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,10 +1,10 @@
 #!/usr/bin/env node
-import { readFile, writeFile, mkdir } from 'node:fs/promises';
-import { resolve, dirname } from 'node:path';
+import { readFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
 import { pathToFileURL } from 'node:url';
 import { watch } from 'chokidar';
-import { scanVarNames } from './scanner.js';
-import { generateCode } from './generator.js';
+import { generate } from './index.js';
+import type { NamingConvention } from './generator.js';
 
 const args = process.argv.slice(2);
 const getArg = (flag: string): string | undefined => {
@@ -18,6 +18,7 @@ interface Config {
   output?: string;
   exclude?: string | string[];
   prefix?: string;
+  naming?: NamingConvention;
 }
 
 async function loadConfig(): Promise<Config> {
@@ -48,12 +49,10 @@ async function run(
   output: string,
   exclude?: string | string[],
   prefix?: string,
+  naming?: NamingConvention,
 ): Promise<void> {
-  const names = await scanVarNames(input, exclude);
-  const code = generateCode(names, prefix);
-  await mkdir(dirname(resolve(output)), { recursive: true });
-  await writeFile(output, code, 'utf8');
-  console.log(`Generated ${names.length} variables → ${output}`);
+  await generate({ input, output, exclude, prefix, naming });
+  console.log(`Generated → ${output}`);
 }
 
 async function main(): Promise<void> {
@@ -62,6 +61,7 @@ async function main(): Promise<void> {
   const output = getArg('--output') ?? config.output;
   const exclude = getArg('--exclude') ?? config.exclude;
   const prefix = getArg('--prefix') ?? config.prefix;
+  const naming = (getArg('--naming') ?? config.naming) as NamingConvention | undefined;
 
   if (!input || !output) {
     console.error('Usage: css-typed-vars --input <glob> --output <file> [--watch]');
@@ -69,13 +69,13 @@ async function main(): Promise<void> {
     process.exit(1);
   }
 
-  await run(input, output, exclude, prefix);
+  await run(input, output, exclude, prefix, naming);
 
   if (watchMode) {
     const patterns = Array.isArray(input) ? input : [input];
     watch(patterns).on('change', (file) => {
       console.log(`Changed: ${file}`);
-      run(input, output, exclude, prefix).catch(console.error);
+      run(input, output, exclude, prefix, naming).catch(console.error);
     });
     console.log('Watching for changes...');
   }

--- a/src/generator.ts
+++ b/src/generator.ts
@@ -1,16 +1,29 @@
-function toCamelCase(cssVarName: string): string {
-  return cssVarName
-    .replace(/^--/, '')
-    .replace(/-([a-z0-9])/g, (_, c: string) => c.toUpperCase());
+export type NamingConvention = 'camelCase' | 'snake' | 'kebab';
+
+function toKey(cssVarName: string, naming: NamingConvention = 'camelCase'): string {
+  const stripped = cssVarName.replace(/^--/, '');
+  if (naming === 'snake') return stripped.replace(/-/g, '_');
+  if (naming === 'kebab') return stripped;
+  return stripped.replace(/-([a-z0-9])/g, (_, c: string) => c.toUpperCase());
 }
 
-function applyPrefix(key: string, prefix: string | undefined): string {
+function applyPrefix(key: string, prefix: string | undefined, naming: NamingConvention = 'camelCase'): string {
   if (!prefix) return key;
+  if (naming === 'snake') return `${prefix}_${key}`;
+  if (naming === 'kebab') return `${prefix}-${key}`;
   return prefix + key.charAt(0).toUpperCase() + key.slice(1);
 }
 
-export function generateCode(varNames: string[], prefix?: string): string {
-  const entries = varNames.map(name => `  ${applyPrefix(toCamelCase(name), prefix)}: 'var(${name})',`);
+function formatKey(key: string, naming: NamingConvention = 'camelCase'): string {
+  if (naming === 'kebab') return `'${key}'`;
+  return key;
+}
+
+export function generateCode(varNames: string[], prefix?: string, naming?: NamingConvention): string {
+  const entries = varNames.map(name => {
+    const key = formatKey(applyPrefix(toKey(name, naming), prefix, naming), naming);
+    return `  ${key}: 'var(${name})',`;
+  });
   return [
     '// generated — do not edit',
     'export const cssVars = {',
@@ -22,9 +35,13 @@ export function generateCode(varNames: string[], prefix?: string): string {
   ].join('\n');
 }
 
-export function generateJs(varNames: string[], prefix?: string): string {
-  const entries = varNames.map(name => `  ${applyPrefix(toCamelCase(name), prefix)}: 'var(${name})',`);
+export function generateJs(varNames: string[], prefix?: string, naming?: NamingConvention): string {
+  const entries = varNames.map(name => {
+    const key = formatKey(applyPrefix(toKey(name, naming), prefix, naming), naming);
+    return `  ${key}: 'var(${name})',`;
+  });
   return [
+    '// generated — do not edit',
     'export const cssVars = {',
     ...entries,
     '};',
@@ -32,8 +49,11 @@ export function generateJs(varNames: string[], prefix?: string): string {
   ].join('\n');
 }
 
-export function generateDeclaration(varNames: string[], prefix?: string): string {
-  const entries = varNames.map(name => `  ${applyPrefix(toCamelCase(name), prefix)}: 'var(${name})';`);
+export function generateDeclaration(varNames: string[], prefix?: string, naming?: NamingConvention): string {
+  const entries = varNames.map(name => {
+    const key = formatKey(applyPrefix(toKey(name, naming), prefix, naming), naming);
+    return `  ${key}: 'var(${name})';`;
+  });
   return [
     'export declare const cssVars: {',
     ...entries,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,22 +1,31 @@
 import { writeFile, mkdir } from 'node:fs/promises';
 import { dirname, resolve } from 'node:path';
 import { scanVarNames } from './scanner.js';
-import { generateCode } from './generator.js';
+import { generateCode, generateJs, generateDeclaration, type NamingConvention } from './generator.js';
 
 export { parseVarNames } from './parser.js';
-export { generateCode } from './generator.js';
+export { generateCode, generateJs, generateDeclaration } from './generator.js';
 export { scanVarNames } from './scanner.js';
+export type { NamingConvention } from './generator.js';
 
 export interface GenerateOptions {
   input: string | string[];
   output: string;
   exclude?: string | string[];
   prefix?: string;
+  naming?: NamingConvention;
 }
 
 export async function generate(options: GenerateOptions): Promise<void> {
   const names = await scanVarNames(options.input, options.exclude);
-  const code = generateCode(names, options.prefix);
-  await mkdir(dirname(resolve(options.output)), { recursive: true });
-  await writeFile(options.output, code, 'utf8');
+  const outPath = resolve(options.output);
+  await mkdir(dirname(outPath), { recursive: true });
+
+  if (options.output.endsWith('.js')) {
+    await writeFile(outPath, generateJs(names, options.prefix, options.naming), 'utf8');
+    const dtsPath = outPath.replace(/\.js$/, '.d.ts');
+    await writeFile(dtsPath, generateDeclaration(names, options.prefix, options.naming), 'utf8');
+  } else {
+    await writeFile(outPath, generateCode(names, options.prefix, options.naming), 'utf8');
+  }
 }

--- a/src/unplugin.ts
+++ b/src/unplugin.ts
@@ -2,7 +2,7 @@ import { createUnplugin } from 'unplugin';
 import { writeFile } from 'node:fs/promises';
 import { join, resolve } from 'node:path';
 import { scanVarNames } from './scanner.js';
-import { generateJs, generateDeclaration } from './generator.js';
+import { generateJs, generateDeclaration, type NamingConvention } from './generator.js';
 
 export interface Options {
   input: string | string[];
@@ -15,6 +15,7 @@ export interface Options {
   dts?: string | false;
   exclude?: string | string[];
   prefix?: string;
+  naming?: NamingConvention;
 }
 
 const VIRTUAL_ID = 'css-typed-vars/vars';
@@ -44,7 +45,7 @@ export default createUnplugin((options: Options) => ({
 
         const dtsPath = getDtsPath(options);
         if (dtsPath) {
-          await writeFile(dtsPath, generateDeclaration(names, options.prefix), 'utf8');
+          await writeFile(dtsPath, generateDeclaration(names, options.prefix, options.naming), 'utf8');
         }
 
         const mod = server.moduleGraph.getModuleById(RESOLVED_ID);
@@ -60,7 +61,7 @@ export default createUnplugin((options: Options) => ({
     const dtsPath = getDtsPath(options);
     if (!dtsPath) return;
     const names = await scanVarNames(options.input, options.exclude);
-    await writeFile(dtsPath, generateDeclaration(names, options.prefix), 'utf8');
+    await writeFile(dtsPath, generateDeclaration(names, options.prefix, options.naming), 'utf8');
   },
 
   resolveId(id: string) {
@@ -70,7 +71,7 @@ export default createUnplugin((options: Options) => ({
   async load(id: string) {
     if (id === RESOLVED_ID) {
       const names = await scanVarNames(options.input, options.exclude);
-      return generateJs(names, options.prefix);
+      return generateJs(names, options.prefix, options.naming);
     }
   },
 }));


### PR DESCRIPTION
Add key naming control and JS output support across CLI, config file, plugin, and programmatic API.

Key changes:
- `src/generator.ts` — new `NamingConvention` type (`'camelCase' | 'snake' | 'kebab'`); replace `toCamelCase` with `toKey(name, naming)` supporting all three conventions; `applyPrefix` is now naming-aware (snake uses `_`, kebab uses `-`, camelCase capitalizes); `formatKey` quotes kebab keys; all three exported functions accept `naming?: NamingConvention` as third parameter; `generateJs` gains `// generated — do not edit` comment
- `src/index.ts` — `GenerateOptions` extended with `naming`; `NamingConvention` re-exported; JS output auto-detected from `.js` extension: generates plain JS + writes `.d.ts` alongside; `generateJs` and `generateDeclaration` re-exported
- `src/unplugin.ts` — `Options` extended with `naming`; all generator call sites updated
- `src/cli.ts` — `Config` extended with `naming`; `--naming` flag added; `run()` now delegates to `generate()` (removes duplication and gets JS output for free)
- `src/__tests__/generator.test.ts` — 5 new tests: snake naming, kebab naming (quoted keys), snake+prefix, kebab+prefix
- `src/__tests__/index.test.ts` — 2 new tests: JS output (`.js` + `.d.ts` generated), snake naming
- `package.json` — version bump `0.2.0` → `0.3.0`
- `README.md` — documented `--naming` flag, JS output, config file and plugin options table updated

Closes #20