### PR TITLE
[CLI] Add --version flag, fix watch for new/deleted files, warn on empty result

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ npx css-typed-vars --input "src/**/*.css" --output src/cssVars.js  # generates .
 | `--prefix` | Prefix for generated keys: `--prefix theme` → `themeColorPrimary` |
 | `--naming` | Key naming: `camelCase` (default), `snake`, `kebab` |
 | `--watch` | Watch for file changes and regenerate |
+| `--version`, `-v` | Print the version number and exit |
 
 CLI flags override values from the config file.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "css-typed-vars",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Generate TypeScript typed constants from CSS custom properties",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -56,6 +56,12 @@ async function run(
 }
 
 async function main(): Promise<void> {
+  if (args.includes('--version') || args.includes('-v')) {
+    const pkg = JSON.parse(await readFile(new URL('../package.json', import.meta.url), 'utf8')) as { version: string };
+    console.log(pkg.version);
+    process.exit(0);
+  }
+
   const config = await loadConfig();
   const input = getArg('--input') ?? config.input;
   const output = getArg('--output') ?? config.output;
@@ -73,10 +79,14 @@ async function main(): Promise<void> {
 
   if (watchMode) {
     const patterns = Array.isArray(input) ? input : [input];
-    watch(patterns).on('change', (file) => {
-      console.log(`Changed: ${file}`);
+    const makeHandler = (label: string) => (file: string) => {
+      console.log(`${label}: ${file}`);
       run(input, output, exclude, prefix, naming).catch(console.error);
-    });
+    };
+    watch(patterns)
+      .on('change', makeHandler('Changed'))
+      .on('add', makeHandler('Added'))
+      .on('unlink', makeHandler('Removed'));
     console.log('Watching for changes...');
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,9 @@ export interface GenerateOptions {
 
 export async function generate(options: GenerateOptions): Promise<void> {
   const names = await scanVarNames(options.input, options.exclude);
+  if (names.length === 0) {
+    console.warn('css-typed-vars: no CSS custom properties found.');
+  }
   const outPath = resolve(options.output);
   await mkdir(dirname(outPath), { recursive: true });
 


### PR DESCRIPTION
Three small CLI improvements for the 0.3.1 patch release.

Key changes:
- `src/cli.ts` — add `--version` / `-v` flag: reads version from `package.json` at runtime and exits; fix watch mode to also listen to `add` and `unlink` chokidar events so new or deleted CSS files trigger regeneration (previously only `change` was handled)
- `src/index.ts` — `generate()` now emits a `console.warn` when `scanVarNames` returns 0 variables, preventing a silent empty-object output
- `README.md` — document `--version` / `-v` flag in the CLI flags table
- `package.json` — bump version to 0.3.1

Closes #23