### PR TITLE
[Parser/CLI/Plugin] Add selectors option to scan CSS variables outside :root

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ npx css-typed-vars --input "src/styles/**/*.{css,scss}" --output src/cssVars.ts 
 npx css-typed-vars --input "src/**/*.css" --output src/cssVars.ts --exclude "**/vendor/**"
 npx css-typed-vars --input "src/**/*.css" --output src/cssVars.ts --prefix theme --naming snake
 npx css-typed-vars --input "src/**/*.css" --output src/cssVars.js  # generates .js + .d.ts
+npx css-typed-vars --input "src/**/*.css" --output src/cssVars.ts --selector ".dark"
 ```
 
 | Flag | Description |
@@ -121,6 +122,7 @@ npx css-typed-vars --input "src/**/*.css" --output src/cssVars.js  # generates .
 | `--exclude` | Glob pattern for files to exclude (single value; use config file for multiple) |
 | `--prefix` | Prefix for generated keys: `--prefix theme` → `themeColorPrimary` |
 | `--naming` | Key naming: `camelCase` (default), `snake`, `kebab` |
+| `--selector` | Extra CSS selector to scan for variables (single value; use config file for multiple) |
 | `--watch` | Watch for file changes and regenerate |
 | `--version`, `-v` | Print the version number and exit |
 
@@ -144,6 +146,7 @@ export default {
   exclude: ['**/vendor/**', '**/node_modules/**'],
   prefix: 'theme',
   naming: 'snake', // 'camelCase' | 'snake' | 'kebab'
+  selectors: ['.dark', '[data-theme="dark"]'],
 };
 ```
 
@@ -241,6 +244,7 @@ Turbopack does not yet have a public plugin API for virtual modules. Use the CLI
 | `exclude` | `string \| string[]` | — | Glob pattern(s) for files to exclude |
 | `prefix` | `string` | — | Prefix for generated keys: `'theme'` → `themeColorPrimary` |
 | `naming` | `'camelCase' \| 'snake' \| 'kebab'` | `'camelCase'` | Key naming convention |
+| `selectors` | `string[]` | — | Extra CSS selectors to scan, e.g. `['.dark', '[data-theme="dark"]']` |
 | `dts` | `string \| false` | inside `node_modules` | Path to write type declarations. `false` to skip |
 
 ---
@@ -297,6 +301,7 @@ await generate({
   exclude: ['**/vendor/**'],
   prefix: 'theme',
   naming: 'snake',           // 'camelCase' | 'snake' | 'kebab'
+  selectors: ['.dark', '[data-theme="dark"]'],
 });
 ```
 
@@ -314,7 +319,7 @@ import { parseVarNames, generateCode, scanVarNames } from 'css-typed-vars';
 | SCSS | `.scss` |
 | Less | `.less` |
 
-Variables must be declared inside a `:root {}` block. Attribute selectors are supported (e.g. `:root[data-theme="dark"]`).
+By default, variables are scanned from `:root {}` blocks (including attribute selectors like `:root[data-theme="dark"]`). Use the `selectors` option to also pick up variables from other selectors such as `.dark` or `[data-theme="dark"]`.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+<img src="https://repository-images.githubusercontent.com/1204912196/ef5412c5-0846-4b94-bf5d-811202144eb9" alt="css-typed-vars" />
+
 <h1>css-typed-vars</h1>
 <p>Generate TypeScript typed constants from CSS custom properties</p>
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "css-typed-vars",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "description": "Generate TypeScript typed constants from CSS custom properties",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -82,6 +82,19 @@ describe('generate', () => {
     expect(result).toContain("color_primary: 'var(--color-primary)'");
   });
 
+  it('picks up variables from additional selectors', async () => {
+    const { writeFile } = await import('node:fs/promises');
+    const input = join(dir, 'selectors-test.css');
+    const output = join(dir, 'selectorVars.ts');
+    await writeFile(input, ':root { --color-primary: red; } .dark { --color-bg: #111; }');
+
+    await generate({ input, output, selectors: ['.dark'] });
+
+    const result = await readFile(output, 'utf8');
+    expect(result).toContain("colorPrimary: 'var(--color-primary)'");
+    expect(result).toContain("colorBg: 'var(--color-bg)'");
+  });
+
   it('applies prefix to generated output', async () => {
     const { writeFile } = await import('node:fs/promises');
     const input = join(dir, 'prefix-test.css');

--- a/src/__tests__/parser.test.ts
+++ b/src/__tests__/parser.test.ts
@@ -69,4 +69,39 @@ describe('parseVarNames', () => {
     const css = `:root { --colorPrimary: red; --color_secondary: blue; }`;
     expect(parseVarNames(css)).toEqual(['--colorPrimary', '--color_secondary']);
   });
+
+  it('picks up variables from additional selectors', () => {
+    const css = `
+      :root { --color-primary: red; }
+      .dark { --color-primary: #000; --color-bg: #111; }
+    `;
+    const result = parseVarNames(css, ['.dark']);
+    expect(result).toContain('--color-primary');
+    expect(result).toContain('--color-bg');
+  });
+
+  it('without selectors option still ignores non-root blocks', () => {
+    const css = `
+      :root { --color-primary: red; }
+      .dark { --color-bg: #111; }
+    `;
+    expect(parseVarNames(css)).toEqual(['--color-primary']);
+  });
+
+  it('supports attribute selector syntax', () => {
+    const css = `[data-theme="dark"] { --color-bg: #111; --color-text: #fff; }`;
+    const result = parseVarNames(css, ['[data-theme="dark"]']);
+    expect(result).toContain('--color-bg');
+    expect(result).toContain('--color-text');
+  });
+
+  it('deduplicates variables across :root and extra selectors', () => {
+    const css = `
+      :root { --color: red; }
+      .dark { --color: #000; --extra: 1px; }
+    `;
+    const result = parseVarNames(css, ['.dark']);
+    expect(result.filter(n => n === '--color')).toHaveLength(1);
+    expect(result).toContain('--extra');
+  });
 });

--- a/src/__tests__/scanner.test.ts
+++ b/src/__tests__/scanner.test.ts
@@ -11,6 +11,7 @@ beforeAll(async () => {
   await writeFile(join(dir, 'a.css'), ':root { --color-primary: red; --spacing-md: 8px; }');
   await writeFile(join(dir, 'b.css'), ':root { --color-secondary: blue; --spacing-md: 8px; }');
   await writeFile(join(dir, 'other.txt'), ':root { --ignored: 1px; }');
+  await writeFile(join(dir, 'theme.css'), ':root { --color-primary: red; } .dark { --color-primary: #000; --dark-bg: #111; }');
   await mkdir(join(dir, 'vendor'));
   await writeFile(join(dir, 'vendor', 'lib.css'), ':root { --vendor-color: #fff; }');
 });
@@ -62,6 +63,18 @@ describe('scanVarNames', () => {
   it('returns all files when exclude is undefined', async () => {
     const result = await scanVarNames(`${dir}/**/*.css`);
     expect(result).toContain('--vendor-color');
+    expect(result).toContain('--color-primary');
+  });
+
+  it('picks up variables from additional selectors', async () => {
+    const result = await scanVarNames(`${dir}/theme.css`, undefined, ['.dark']);
+    expect(result).toContain('--color-primary');
+    expect(result).toContain('--dark-bg');
+  });
+
+  it('without selectors option ignores non-root blocks', async () => {
+    const result = await scanVarNames(`${dir}/theme.css`);
+    expect(result).not.toContain('--dark-bg');
     expect(result).toContain('--color-primary');
   });
 });

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -19,6 +19,7 @@ interface Config {
   exclude?: string | string[];
   prefix?: string;
   naming?: NamingConvention;
+  selectors?: string[];
 }
 
 async function loadConfig(): Promise<Config> {
@@ -50,8 +51,9 @@ async function run(
   exclude?: string | string[],
   prefix?: string,
   naming?: NamingConvention,
+  selectors?: string[],
 ): Promise<void> {
-  await generate({ input, output, exclude, prefix, naming });
+  await generate({ input, output, exclude, prefix, naming, selectors });
   console.log(`Generated → ${output}`);
 }
 
@@ -68,6 +70,8 @@ async function main(): Promise<void> {
   const exclude = getArg('--exclude') ?? config.exclude;
   const prefix = getArg('--prefix') ?? config.prefix;
   const naming = (getArg('--naming') ?? config.naming) as NamingConvention | undefined;
+  const selectorArg = getArg('--selector');
+  const selectors = selectorArg ? [selectorArg] : config.selectors;
 
   if (!input || !output) {
     console.error('Usage: css-typed-vars --input <glob> --output <file> [--watch]');
@@ -75,13 +79,13 @@ async function main(): Promise<void> {
     process.exit(1);
   }
 
-  await run(input, output, exclude, prefix, naming);
+  await run(input, output, exclude, prefix, naming, selectors);
 
   if (watchMode) {
     const patterns = Array.isArray(input) ? input : [input];
     const makeHandler = (label: string) => (file: string) => {
       console.log(`${label}: ${file}`);
-      run(input, output, exclude, prefix, naming).catch(console.error);
+      run(input, output, exclude, prefix, naming, selectors).catch(console.error);
     };
     watch(patterns)
       .on('change', makeHandler('Changed'))

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,10 +14,11 @@ export interface GenerateOptions {
   exclude?: string | string[];
   prefix?: string;
   naming?: NamingConvention;
+  selectors?: string[];
 }
 
 export async function generate(options: GenerateOptions): Promise<void> {
-  const names = await scanVarNames(options.input, options.exclude);
+  const names = await scanVarNames(options.input, options.exclude, options.selectors);
   if (names.length === 0) {
     console.warn('css-typed-vars: no CSS custom properties found.');
   }

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -1,12 +1,16 @@
-export function parseVarNames(css: string): string[] {
+export function parseVarNames(css: string, selectors?: string[]): string[] {
   const stripped = css
     .replace(/\/\*[\s\S]*?\*\//g, '')
     .replace(/\/\/.*$/gm, '');
   const names = new Set<string>();
-  const rootRegex = /:root[^{]*\{([^}]*)}/g;
-  for (const match of stripped.matchAll(rootRegex)) {
-    for (const prop of match[1].matchAll(/--[\w-]+(?=\s*:)/g)) {
-      names.add(prop[0]);
+  const allSelectors = [':root', ...(selectors ?? [])];
+  for (const sel of allSelectors) {
+    const escaped = sel.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const regex = new RegExp(`${escaped}[^{]*\\{([^}]*)\\}`, 'g');
+    for (const match of stripped.matchAll(regex)) {
+      for (const prop of match[1].matchAll(/--[\w-]+(?=\s*:)/g)) {
+        names.add(prop[0]);
+      }
     }
   }
   return [...names];

--- a/src/scanner.ts
+++ b/src/scanner.ts
@@ -5,6 +5,7 @@ import { parseVarNames } from './parser.js';
 export async function scanVarNames(
   patterns: string | string[],
   exclude?: string | string[],
+  selectors?: string[],
 ): Promise<string[]> {
   const normalized = (Array.isArray(patterns) ? patterns : [patterns]).map((p) =>
     p.replace(/\\/g, '/'),
@@ -17,7 +18,7 @@ export async function scanVarNames(
   await Promise.all(
     files.map(async (file) => {
       const css = await readFile(file, 'utf8');
-      for (const name of parseVarNames(css)) {
+      for (const name of parseVarNames(css, selectors)) {
         all.add(name);
       }
     }),

--- a/src/unplugin.ts
+++ b/src/unplugin.ts
@@ -16,6 +16,7 @@ export interface Options {
   exclude?: string | string[];
   prefix?: string;
   naming?: NamingConvention;
+  selectors?: string[];
 }
 
 const VIRTUAL_ID = 'css-typed-vars/vars';
@@ -41,7 +42,7 @@ export default createUnplugin((options: Options) => ({
       server.watcher.on('change', async (file: string) => {
         if (!/\.(css|scss|less)$/i.test(file)) return;
 
-        const names = await scanVarNames(options.input, options.exclude);
+        const names = await scanVarNames(options.input, options.exclude, options.selectors);
 
         const dtsPath = getDtsPath(options);
         if (dtsPath) {
@@ -60,7 +61,7 @@ export default createUnplugin((options: Options) => ({
   async buildStart() {
     const dtsPath = getDtsPath(options);
     if (!dtsPath) return;
-    const names = await scanVarNames(options.input, options.exclude);
+    const names = await scanVarNames(options.input, options.exclude, options.selectors);
     await writeFile(dtsPath, generateDeclaration(names, options.prefix, options.naming), 'utf8');
   },
 
@@ -70,7 +71,7 @@ export default createUnplugin((options: Options) => ({
 
   async load(id: string) {
     if (id === RESOLVED_ID) {
-      const names = await scanVarNames(options.input, options.exclude);
+      const names = await scanVarNames(options.input, options.exclude, options.selectors);
       return generateJs(names, options.prefix, options.naming);
     }
   },


### PR DESCRIPTION
Adds a `selectors` option to scan CSS custom properties from arbitrary selectors (e.g. `.dark`, `[data-theme="dark"]`), not only `:root`.

Key changes:
- `src/parser.ts` — `parseVarNames(css, selectors?)` now accepts an optional list of extra CSS selectors; builds a per-selector regex, escaping special chars, and collects vars from all matched blocks; `:root` is always included
- `src/scanner.ts` — `scanVarNames(patterns, exclude?, selectors?)` passes `selectors` to `parseVarNames`
- `src/index.ts` — `GenerateOptions` gets `selectors?: string[]`, forwarded to `scanVarNames`
- `src/cli.ts` — `--selector <selector>` flag (single value from CLI, array from config file); `Config` interface extended with `selectors`
- `src/unplugin.ts` — `Options` gets `selectors?: string[]`, forwarded to `scanVarNames` in all three hooks
- `src/__tests__/parser.test.ts` — 4 new cases: extra selector, backward compat without selectors, attribute selector syntax, deduplication across `:root` and extra selectors
- `src/__tests__/scanner.test.ts` — 2 new cases: selectors option picks up non-root vars; without selectors non-root vars are ignored
- `src/__tests__/index.test.ts` — 1 new integration case: `selectors` flows end-to-end into generated output
- `README.md` — `--selector` flag in table, `selectors` in config example and plugin options table, programmatic API example, updated Supported formats note
- `package.json` — bump version to 0.4.0

Closes #24