### PR TITLE
[Scanner/CLI/Generator] Patch fixes: sorted output, multi-selector, generateJs tests

### DIFF
--- a/src/__tests__/generator.test.ts
+++ b/src/__tests__/generator.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { generateCode, generateDeclaration } from '../generator.js';
+import { generateCode, generateDeclaration, generateJs } from '../generator.js';
 
 describe('generateCode', () => {
   it('generates typed constants from var names', () => {
@@ -75,6 +75,45 @@ describe('generateCode', () => {
   it('kebab naming with prefix uses hyphen separator', () => {
     const result = generateCode(['--color-primary'], 'theme', 'kebab');
     expect(result).toContain("'theme-color-primary': 'var(--color-primary)'");
+  });
+});
+
+describe('generateJs', () => {
+  it('generates plain JS export without as const or CssVarName type', () => {
+    const result = generateJs(['--color-primary', '--spacing-md']);
+    expect(result).toContain("colorPrimary: 'var(--color-primary)'");
+    expect(result).toContain("spacingMd: 'var(--spacing-md)'");
+    expect(result).toContain('export const cssVars = {');
+    expect(result).toContain('};');
+    expect(result).not.toContain('as const');
+    expect(result).not.toContain('CssVarName');
+  });
+
+  it('includes generated header comment', () => {
+    const result = generateJs(['--color-primary']);
+    expect(result).toContain('// generated — do not edit');
+  });
+
+  it('returns empty cssVars for empty input', () => {
+    const result = generateJs([]);
+    expect(result).toContain('export const cssVars = {');
+    expect(result).toContain('};');
+    expect(result).not.toContain('var(--');
+  });
+
+  it('applies prefix to generated keys', () => {
+    const result = generateJs(['--color-primary'], 'theme');
+    expect(result).toContain("themeColorPrimary: 'var(--color-primary)'");
+  });
+
+  it('snake naming converts hyphens to underscores', () => {
+    const result = generateJs(['--color-primary'], undefined, 'snake');
+    expect(result).toContain("color_primary: 'var(--color-primary)'");
+  });
+
+  it('kebab naming keeps hyphens as quoted key', () => {
+    const result = generateJs(['--color-primary'], undefined, 'kebab');
+    expect(result).toContain("'color-primary': 'var(--color-primary)'");
   });
 });
 

--- a/src/__tests__/scanner.test.ts
+++ b/src/__tests__/scanner.test.ts
@@ -77,4 +77,11 @@ describe('scanVarNames', () => {
     expect(result).not.toContain('--dark-bg');
     expect(result).toContain('--color-primary');
   });
+
+  it('returns variables in stable sorted order across multiple runs', async () => {
+    const first = await scanVarNames(`${dir}/*.css`);
+    const second = await scanVarNames(`${dir}/*.css`);
+    expect(first).toEqual(second);
+    expect(first).toEqual([...first].sort());
+  });
 });

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -11,6 +11,13 @@ const getArg = (flag: string): string | undefined => {
   const i = args.indexOf(flag);
   return i !== -1 ? args[i + 1] : undefined;
 };
+const getArgs = (flag: string): string[] => {
+  const result: string[] = [];
+  for (let i = 0; i < args.length - 1; i++) {
+    if (args[i] === flag) result.push(args[i + 1]);
+  }
+  return result;
+};
 const watchMode = args.includes('--watch');
 
 interface Config {
@@ -70,8 +77,8 @@ async function main(): Promise<void> {
   const exclude = getArg('--exclude') ?? config.exclude;
   const prefix = getArg('--prefix') ?? config.prefix;
   const naming = (getArg('--naming') ?? config.naming) as NamingConvention | undefined;
-  const selectorArg = getArg('--selector');
-  const selectors = selectorArg ? [selectorArg] : config.selectors;
+  const selectorArgs = getArgs('--selector');
+  const selectors = selectorArgs.length > 0 ? selectorArgs : config.selectors;
 
   if (!input || !output) {
     console.error('Usage: css-typed-vars --input <glob> --output <file> [--watch]');

--- a/src/scanner.ts
+++ b/src/scanner.ts
@@ -23,5 +23,5 @@ export async function scanVarNames(
       }
     }),
   );
-  return [...all];
+  return [...all].sort();
 }


### PR DESCRIPTION
Three patch bug fixes.

Key changes:
- `src/scanner.ts` — sort result of `scanVarNames` before returning; fixes non-deterministic order caused by `Promise.all` over multiple files
- `src/__tests__/scanner.test.ts` — assert sorted order is stable across runs
- `src/cli.ts` — add `getArgs` helper; `--selector` now collects all occurrences instead of only the first
- `src/__tests__/generator.test.ts` — add 6 tests for `generateJs`

Closes #31