### PR TITLE
[Plugin] Handle add and unlink events in Vite watch mode

### DIFF
--- a/src/unplugin.ts
+++ b/src/unplugin.ts
@@ -42,7 +42,7 @@ export default createUnplugin((options: Options) => {
       enforce: 'pre' as const,
 
       configureServer(server: any) {
-        server.watcher.on('change', async (file: string) => {
+        const handle = async (file: string) => {
           if (!/\.(css|scss|less)$/i.test(file)) return;
 
           cachedNames = null;
@@ -58,7 +58,11 @@ export default createUnplugin((options: Options) => {
             server.moduleGraph.invalidateModule(mod);
             server.ws.send({ type: 'full-reload' });
           }
-        });
+        };
+
+        server.watcher.on('change', handle);
+        server.watcher.on('add', handle);
+        server.watcher.on('unlink', handle);
       },
     },
 


### PR DESCRIPTION
Adding or deleting a CSS file in Vite dev server no longer requires a manual restart.

Key changes:
- `src/unplugin.ts` — extract watcher callback into `handle`; register it on `change`, `add`, and `unlink`; previously only `change` was handled so new/deleted CSS files were silently ignored

Closes #35