### PR TITLE
[CI] Switch npm publish to Trusted Publishing (OIDC)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      id-token: write
     steps:
       - uses: actions/checkout@v4
         with:
@@ -102,8 +103,6 @@ jobs:
 
       - name: Publish to npm
         run: npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Open version bump PR
         run: |


### PR DESCRIPTION
Eliminates the long-lived NPM_TOKEN secret by using OIDC — npm issues a short-lived token per workflow run automatically.

Key changes:
- `.github/workflows/release.yml` — add `id-token: write` permission; remove `NODE_AUTH_TOKEN` env var from the publish step

**Before merging:** add this repo as a Trusted Publisher on npmjs.com → package `css-typed-vars` → Settings → Trusted Publishers → GitHub → owner `StanislavKozachenko`, repo `css-typed-vars`, workflow `release.yml`.

Closes #42