### PR TITLE
[CI] Include refactor/perf/docs/ci commits in CHANGELOG

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,13 +58,14 @@ jobs:
             local prefix=$1
             if [ -n "$LAST_TAG" ]; then
               git log "${LAST_TAG}..HEAD" --pretty=format:"%s" \
-                | grep -E "^${prefix}(\([^)]+\))?:" \
-                | sed -E "s/^${prefix}(\([^)]+\))?: /- /" || true
+                | grep -E "^(${prefix})(\([^)]+\))?:" \
+                | sed -E "s/^[a-z]+(\([^)]+\))?: /- /" || true
             fi
           }
 
           ADDED=$(get_section "feat")
           FIXED=$(get_section "fix")
+          CHANGED=$(get_section "refactor|perf|docs|ci")
 
           {
             echo "## [${VERSION}] - ${DATE}"
@@ -79,6 +80,12 @@ jobs:
               echo "### Fixed"
               echo ""
               echo "$FIXED"
+              echo ""
+            fi
+            if [ -n "$CHANGED" ]; then
+              echo "### Changed"
+              echo ""
+              echo "$CHANGED"
               echo ""
             fi
             echo "---"


### PR DESCRIPTION
Extends CHANGELOG generation to capture all meaningful commit types.

Key changes:
- `.github/workflows/release.yml` — add `CHANGED` variable collecting `refactor|perf|docs|ci` commits; emit `### Changed` section if non-empty; use `[a-z]+` in sed to strip whichever prefix matched

Closes #45