### PR TITLE
[Generator/CLI] Fix digit-starting keys and multi-value --exclude

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ npx css-typed-vars --input "src/**/*.css" --output src/cssVars.ts --selector ".d
 |------|-------------|
 | `--input` | Glob pattern for CSS/SCSS/Less files |
 | `--output` | Output file. `.ts` → TypeScript, `.js` → JavaScript + `.d.ts` alongside |
-| `--exclude` | Glob pattern for files to exclude (single value; use config file for multiple) |
+| `--exclude` | Glob pattern for files to exclude (repeatable: `--exclude "**/a/**" --exclude "**/b/**"`) |
 | `--prefix` | Prefix for generated keys: `--prefix theme` → `themeColorPrimary` |
 | `--naming` | Key naming: `camelCase` (default), `snake`, `kebab` |
 | `--selector` | Extra CSS selector to scan for variables (single value; use config file for multiple) |

--- a/src/__tests__/generator.test.ts
+++ b/src/__tests__/generator.test.ts
@@ -76,6 +76,22 @@ describe('generateCode', () => {
     const result = generateCode(['--color-primary'], 'theme', 'kebab');
     expect(result).toContain("'theme-color-primary': 'var(--color-primary)'");
   });
+
+  it('prefixes digit-starting key with underscore (camelCase)', () => {
+    const result = generateCode(['--1st-color', '--2nd-item']);
+    expect(result).toContain("_1stColor: 'var(--1st-color)'");
+    expect(result).toContain("_2ndItem: 'var(--2nd-item)'");
+  });
+
+  it('prefixes digit-starting key with underscore (snake)', () => {
+    const result = generateCode(['--1st-color'], undefined, 'snake');
+    expect(result).toContain("_1st_color: 'var(--1st-color)'");
+  });
+
+  it('does not prefix digit-starting key in kebab (already quoted)', () => {
+    const result = generateCode(['--1st-color'], undefined, 'kebab');
+    expect(result).toContain("'1st-color': 'var(--1st-color)'");
+  });
 });
 
 describe('generateJs', () => {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -74,7 +74,8 @@ async function main(): Promise<void> {
   const config = await loadConfig();
   const input = getArg('--input') ?? config.input;
   const output = getArg('--output') ?? config.output;
-  const exclude = getArg('--exclude') ?? config.exclude;
+  const excludeArgs = getArgs('--exclude');
+  const exclude = excludeArgs.length > 0 ? excludeArgs : config.exclude;
   const prefix = getArg('--prefix') ?? config.prefix;
   const naming = (getArg('--naming') ?? config.naming) as NamingConvention | undefined;
   const selectorArgs = getArgs('--selector');

--- a/src/generator.ts
+++ b/src/generator.ts
@@ -2,9 +2,11 @@ export type NamingConvention = 'camelCase' | 'snake' | 'kebab';
 
 function toKey(cssVarName: string, naming: NamingConvention = 'camelCase'): string {
   const stripped = cssVarName.replace(/^--/, '');
-  if (naming === 'snake') return stripped.replace(/-/g, '_');
   if (naming === 'kebab') return stripped;
-  return stripped.replace(/-([a-z0-9])/g, (_, c: string) => c.toUpperCase());
+  const key = naming === 'snake'
+    ? stripped.replace(/-/g, '_')
+    : stripped.replace(/-([a-z0-9])/g, (_, c: string) => c.toUpperCase());
+  return /^\d/.test(key) ? `_${key}` : key;
 }
 
 function applyPrefix(key: string, prefix: string | undefined, naming: NamingConvention = 'camelCase'): string {


### PR DESCRIPTION
Two patch bug fixes.

Key changes:
- `src/generator.ts` — prepend `_` when a generated key starts with a digit (e.g. `--1st-color` → `_1stColor`); applies to `camelCase` and `snake`, exempt for `kebab` since keys are always quoted
- `src/__tests__/generator.test.ts` — 3 new cases covering digit-starting keys for each naming convention
- `src/cli.ts` — `--exclude` now collects all occurrences via `getArgs`; `--exclude "**/a/**" --exclude "**/b/**"` previously dropped all but the first
- `README.md` — document `--exclude` as repeatable

Closes #47
Closes #48