### PR TITLE
[Generator] Prefix digit-starting keys with underscore

### DIFF
--- a/src/__tests__/generator.test.ts
+++ b/src/__tests__/generator.test.ts
@@ -76,6 +76,22 @@ describe('generateCode', () => {
     const result = generateCode(['--color-primary'], 'theme', 'kebab');
     expect(result).toContain("'theme-color-primary': 'var(--color-primary)'");
   });
+
+  it('prefixes digit-starting key with underscore (camelCase)', () => {
+    const result = generateCode(['--1st-color', '--2nd-item']);
+    expect(result).toContain("_1stColor: 'var(--1st-color)'");
+    expect(result).toContain("_2ndItem: 'var(--2nd-item)'");
+  });
+
+  it('prefixes digit-starting key with underscore (snake)', () => {
+    const result = generateCode(['--1st-color'], undefined, 'snake');
+    expect(result).toContain("_1st_color: 'var(--1st-color)'");
+  });
+
+  it('does not prefix digit-starting key in kebab (already quoted)', () => {
+    const result = generateCode(['--1st-color'], undefined, 'kebab');
+    expect(result).toContain("'1st-color': 'var(--1st-color)'");
+  });
 });
 
 describe('generateJs', () => {

--- a/src/generator.ts
+++ b/src/generator.ts
@@ -2,9 +2,11 @@ export type NamingConvention = 'camelCase' | 'snake' | 'kebab';
 
 function toKey(cssVarName: string, naming: NamingConvention = 'camelCase'): string {
   const stripped = cssVarName.replace(/^--/, '');
-  if (naming === 'snake') return stripped.replace(/-/g, '_');
   if (naming === 'kebab') return stripped;
-  return stripped.replace(/-([a-z0-9])/g, (_, c: string) => c.toUpperCase());
+  const key = naming === 'snake'
+    ? stripped.replace(/-/g, '_')
+    : stripped.replace(/-([a-z0-9])/g, (_, c: string) => c.toUpperCase());
+  return /^\d/.test(key) ? `_${key}` : key;
 }
 
 function applyPrefix(key: string, prefix: string | undefined, naming: NamingConvention = 'camelCase'): string {


### PR DESCRIPTION
CSS variables like `--1st-color` generated invalid JS identifiers (`1stColor`).

Key changes:
- `src/generator.ts` — prepend `_` when key starts with a digit; applies to `camelCase` and `snake`; `kebab` exempt as keys are always quoted
- `src/__tests__/generator.test.ts` — 3 new cases for digit-starting keys across naming conventions

Closes #47