### PR TITLE
[CLI] Support multiple --exclude flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ npx css-typed-vars --input "src/**/*.css" --output src/cssVars.ts --selector ".d
 |------|-------------|
 | `--input` | Glob pattern for CSS/SCSS/Less files |
 | `--output` | Output file. `.ts` → TypeScript, `.js` → JavaScript + `.d.ts` alongside |
-| `--exclude` | Glob pattern for files to exclude (single value; use config file for multiple) |
+| `--exclude` | Glob pattern for files to exclude (repeatable: `--exclude "**/a/**" --exclude "**/b/**"`) |
 | `--prefix` | Prefix for generated keys: `--prefix theme` → `themeColorPrimary` |
 | `--naming` | Key naming: `camelCase` (default), `snake`, `kebab` |
 | `--selector` | Extra CSS selector to scan for variables (single value; use config file for multiple) |

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -74,7 +74,8 @@ async function main(): Promise<void> {
   const config = await loadConfig();
   const input = getArg('--input') ?? config.input;
   const output = getArg('--output') ?? config.output;
-  const exclude = getArg('--exclude') ?? config.exclude;
+  const excludeArgs = getArgs('--exclude');
+  const exclude = excludeArgs.length > 0 ? excludeArgs : config.exclude;
   const prefix = getArg('--prefix') ?? config.prefix;
   const naming = (getArg('--naming') ?? config.naming) as NamingConvention | undefined;
   const selectorArgs = getArgs('--selector');


### PR DESCRIPTION
`--exclude` accepted only a single value; subsequent flags were silently dropped.

Key changes:
- `src/cli.ts` — collect all `--exclude` occurrences via `getArgs`; consistent with how `--selector` works
- `README.md` — document `--exclude` as repeatable

Closes #48