### PR TITLE
[CI] Add fetch-depth: 0 to release checkout for CHANGELOG generation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           token: ${{ secrets.RELEASE_TOKEN }}
+          fetch-depth: 0
 
       - uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
Shallow clone (default `fetch-depth: 1`) has no tags, so `git describe --tags` returns empty and CHANGELOG sections are never populated.

Key changes:
- `.github/workflows/release.yml` — add `fetch-depth: 0` to checkout step

Closes #53