### PR TITLE
[CLI] Support multiple --input flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ npx css-typed-vars --input "src/**/*.css" --output src/cssVars.ts --selector ".d
 
 | Flag | Description |
 |------|-------------|
-| `--input` | Glob pattern for CSS/SCSS/Less files |
+| `--input` | Glob pattern for CSS/SCSS/Less files (repeatable: `--input "src/**/*.css" --input "lib/**/*.css"`) |
 | `--output` | Output file. `.ts` → TypeScript, `.js` → JavaScript + `.d.ts` alongside |
 | `--exclude` | Glob pattern for files to exclude (repeatable: `--exclude "**/a/**" --exclude "**/b/**"`) |
 | `--prefix` | Prefix for generated keys: `--prefix theme` → `themeColorPrimary` |

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -72,7 +72,8 @@ async function main(): Promise<void> {
   }
 
   const config = await loadConfig();
-  const input = getArg('--input') ?? config.input;
+  const inputArgs = getArgs('--input');
+  const input = inputArgs.length > 0 ? inputArgs : config.input;
   const output = getArg('--output') ?? config.output;
   const excludeArgs = getArgs('--exclude');
   const exclude = excludeArgs.length > 0 ? excludeArgs : config.exclude;


### PR DESCRIPTION
`--input` accepted only a single value; config file supports `input: string[]` but CLI did not.

Key changes:
- `src/cli.ts` — collect all `--input` occurrences via `getArgs`; consistent with `--selector` and `--exclude`
- `README.md` — document `--input` as repeatable

Closes #56