### PR TITLE
[CLI] Warn on malformed config file instead of silently ignoring it

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -45,8 +45,10 @@ async function loadConfig(): Promise<Config> {
         const mod = await import(pathToFileURL(path).href) as { default: Config };
         return mod.default;
       }
-    } catch {
-      // file not found or parse error — try next
+    } catch (err) {
+      const code = (err as NodeJS.ErrnoException).code;
+      if (code === 'ENOENT' || code === 'ERR_MODULE_NOT_FOUND' || code === 'MODULE_NOT_FOUND') continue;
+      console.warn(`css-typed-vars: failed to load config "${file}": ${(err as Error).message}`);
     }
   }
   return {};


### PR DESCRIPTION
Distinguishes between "config file not found" and "config file is broken" in `loadConfig()`.

Key changes:
- `src/cli.ts` — `loadConfig()` now checks the error code: `ENOENT`, `ERR_MODULE_NOT_FOUND`, `MODULE_NOT_FOUND` → skip silently (file simply doesn't exist); any other error → `console.warn` with the file name and error message

Closes #61